### PR TITLE
Tweaks for reverse proxy...

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,6 @@ var connect = require('connect')
 
 // create socket.io server
 var io = require('socket.io').listen(server)
-io.set('log level', 1)
 
 
 // serve static files

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "connect": "~2.7.2",
-    "socket.io": "~0.9.13",
+    "socket.io": "~1.3.7",
     "commander": "~1.1.1",
     "headless-terminal": "~0.3.1",
     "send": "*"

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@ body {
 <div class="terminal-container">
   <div class="terminal" id="terminal"></div>
 </div>
-<script src="/socket.io/socket.io.js"></script>
+<script src="socket.io/socket.io.js"></script>
 <script src="components/screen-buffer/screen-buffer.js"></script>
 <script src="components/screen-buffer/patch.js"></script>
 <script src="components/ttycast-client/display-buffer.js"></script>


### PR DESCRIPTION
Two small tweaks:

- `/socket.io/socket.io.js` does not neet to be an absolute path.
- Bump `socket.io` to version 1.3.7.

These tweaks make it easier to put `ttycast` behind a reverse proxy:

- Because the path of `socket.io.js` is just right.
- Because `socket.io` 1.3.7 is better (faster) at falling back to COMET/polling when it cannot establish the websocket connection it wants.

Apache config is then just:

    ProxyPass /socket.io/ http://localhost:13377/socket.io/
    ProxyPass /ttycast/ http://localhost:13377/

This isn't great, but the configuration and UX is considerably better than previously.

(This is a better solution than adding a new domain, in my case, because my users do not have to re-authenticate themselves.)