### PR TITLE
Only send terminal image to newly-connected client.

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ var buffer = new ScreenBuffer()
 // when a client is connected, it is initialized with an empty buffer.
 // we patch its buffer to our current state
 io.sockets.on('connection', function(sock) {
-  io.sockets.emit('data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
+  sock.emit('data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
 })
 
 // when the terminal's screen buffer is changed,


### PR DESCRIPTION
Previously, when a client connects, the current terminal image was refreshed in *all* clients.

That's `n*(n-1)` (or `O(n^2)`) messages to get n clients set up.

However, there's no need to refresh existing clients.

(My own use case involves about 50-100 clients, so this matters a bit.)