### PR TITLE
Rename 'data' as 'terminal-data'.

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,6 @@ var connect = require('connect')
 
 // create socket.io server
 var io = require('socket.io').listen(server)
-io.set('log level', 1)
 
 
 // serve static files

--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ var buffer = new ScreenBuffer()
 // when a client is connected, it is initialized with an empty buffer.
 // we patch its buffer to our current state
 io.sockets.on('connection', function(sock) {
-  sock.emit('data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
+  sock.emit('terminal-data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
 })
 
 // when the terminal's screen buffer is changed,
@@ -84,11 +84,11 @@ term.on('change', function() {
 
 function broadcast() {
   timeout = null
-  
+
   var operations = ScreenBuffer.diff(buffer, term.displayBuffer)
   if (operations.length === 0) return
 
-  io.sockets.emit('data', operations)
+  io.sockets.emit('terminal-data', operations)
   ScreenBuffer.patch(buffer, operations)
 }
 

--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ var buffer = new ScreenBuffer()
 // when a client is connected, it is initialized with an empty buffer.
 // we patch its buffer to our current state
 io.sockets.on('connection', function(sock) {
-  io.sockets.emit('data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
+  io.sockets.emit('terminal-data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
 })
 
 // when the terminal's screen buffer is changed,
@@ -89,7 +89,7 @@ function broadcast() {
   var operations = ScreenBuffer.diff(buffer, term.displayBuffer)
   if (operations.length === 0) return
 
-  io.sockets.emit('data', operations)
+  io.sockets.emit('terminal-data', operations)
   ScreenBuffer.patch(buffer, operations)
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "connect": "~2.7.2",
-    "socket.io": "~0.9.13",
+    "socket.io": "~1.3.7",
     "commander": "~1.1.1",
     "headless-terminal": "~0.3.1",
     "send": "*"

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@ body {
 <div class="terminal-container">
   <div class="terminal" id="terminal"></div>
 </div>
-<script src="/socket.io/socket.io.js"></script>
+<script src="socket.io/socket.io.js"></script>
 <script src="components/screen-buffer/screen-buffer.js"></script>
 <script src="components/screen-buffer/patch.js"></script>
 <script src="components/ttycast-client/display-buffer.js"></script>

--- a/static/ttycast.js
+++ b/static/ttycast.js
@@ -6,7 +6,7 @@ window.onload = function() {
     , buf = new DisplayBuffer(el)
 
   var socket = io.connect()
-  socket.on('data', function(operations) {
+  socket.on('terminal-data', function(operations) {
     ScreenBuffer.patch(buf, operations)
   })
 


### PR DESCRIPTION
If you want to use the socket connection for transporting anything other than terminal data, then the name 'data' is probably too generic.  If we make it more descriptive, then the sources and destinations are clearer.

Use case:  I want to have a terminal window editing a file, but also the full file contents below.  And, to transmit those contents, I want to re-use the socket connection.  It would be helpful if the naming of the terminal data were descriptive.

(I get that this is a matter of taste and a no-op.  Just discard it if you want.)
