### PR TITLE
Rename 'data' as 'terminal-data'.

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ var buffer = new ScreenBuffer()
 // when a client is connected, it is initialized with an empty buffer.
 // we patch its buffer to our current state
 io.sockets.on('connection', function(sock) {
-  sock.emit('data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
+  sock.emit('terminal-data', ScreenBuffer.diff(new ScreenBuffer(), buffer))
 })
 
 // when the terminal's screen buffer is changed,
@@ -84,11 +84,11 @@ term.on('change', function() {
 
 function broadcast() {
   timeout = null
-  
+
   var operations = ScreenBuffer.diff(buffer, term.displayBuffer)
   if (operations.length === 0) return
 
-  io.sockets.emit('data', operations)
+  io.sockets.emit('terminal-data', operations)
   ScreenBuffer.patch(buffer, operations)
 }
 
@@ -99,3 +99,5 @@ server.listen(Number(process.env.PORT) || 13377, function() {
   console.log('ttycast listening on %s port %s', address.address, address.port)
 })
 
+// export the socket so that it can be re-used by other apps
+module.exports.io = io

--- a/static/ttycast.js
+++ b/static/ttycast.js
@@ -6,7 +6,7 @@ window.onload = function() {
     , buf = new DisplayBuffer(el)
 
   var socket = io.connect()
-  socket.on('data', function(operations) {
+  socket.on('terminal-data', function(operations) {
     ScreenBuffer.patch(buf, operations)
   })
 


### PR DESCRIPTION
(My git-foo is weak.  This replaces #16.)

If you want to use the socket connection for transporting anything other than terminal data, then the name 'data' is probably too generic. If we make it more descriptive, then the sources and destinations are clearer.

Use case: I want to have a terminal window editing a file, but also the full file contents below. And, to transmit those contents, I want to re-use the socket connection. It would be helpful if the naming of the terminal data were descriptive.

**Important**

Here, `app.js` also now exports the socket (`io`).  I could just copy `app.js` and work from there.  However, if you're willing to accept the export, then I can keep `app.js` and benefit from any future improvements.
