### PR TITLE
Have client onload() return the socket

### DIFF
--- a/static/ttycast.js
+++ b/static/ttycast.js
@@ -10,4 +10,5 @@ window.onload = function() {
     ScreenBuffer.patch(buf, operations)
   })
 
+  return socket
 }


### PR DESCRIPTION
This way, other JS in the client can use the socket too.

This is the last change I need to get my own little project running, and is the client-side equivalent of [this](https://github.com/dtinth/ttycast/pull/17/files#diff-0364f57fbff2fabbe941ed20c328ef1aR102).
